### PR TITLE
Update ContentEditController.php

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -322,7 +322,10 @@ class ContentEditController extends TwigAwareController implements BackendZone
 
         if ($field->getDefinition()->get('localize')) {
             $field->setLocale($locale);
-            $this->em->refresh($field);
+            
+            if ($this->em->contains($field)) {
+                $this->em->refresh($field);
+            }
         }
 
         // If the value is an array that contains a string of JSON, parse it


### PR DESCRIPTION
When adding new fields with `localize: true` to content and then saving the content for the first time the Controller breaks on trying to refresh the Field entity, but it is not persisted yet and can not refresh because of that